### PR TITLE
chore: update react-email from v5 to v6.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "biome check ."
   },
   "dependencies": {
-    "@react-email/components": "0.5.1",
     "react": "19.1.0",
+    "react-email": "6.1.4",
     "react-dom": "19.1.0",
     "resend": "6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "react": "19.1.0",
-    "react-email": "6.1.4",
     "react-dom": "19.1.0",
     "resend": "6.0.1"
   },


### PR DESCRIPTION
## Summary

- Replace `@react-email/components` with `react-email` v6.1.4

Closes DEV-491